### PR TITLE
Add basic Jupyter integration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+      - dev
 
 jobs:
   test:

--- a/elsie/box.py
+++ b/elsie/box.py
@@ -131,5 +131,8 @@ class Box(BoxMixin):
         self._show_info = self._show_info.ensure_steps(steps)
         self.slide.max_step = max(self.slide.max_step, steps)
 
+    def _repr_html_(self):
+        return self.slide._repr_html_()
+
 
 from .boxitem import BoxItem  # noqa

--- a/elsie/boxmixin.py
+++ b/elsie/boxmixin.py
@@ -63,7 +63,7 @@ class BoxMixin:
         below=None,
         name=None,
     ):
-        """ Create a new child box
+        """Create a new child box
 
         Position:
 

--- a/elsie/jupyter.py
+++ b/elsie/jupyter.py
@@ -1,0 +1,101 @@
+import uuid
+
+from .slidecls import Slide
+
+
+def get_javascript(max_step: int, slide_id: str) -> str:
+    # Divided into two parts to for easier {} interpolation
+    p1 = f"""
+var active_step = 1;
+var max_step = {max_step};
+var slide_id = ".{slide_id}";
+"""
+
+    p2 = """
+function getSelector(selector) {
+    return slide_id + " > " + selector;
+}
+
+function updateState(step) {
+    var step_str = step.toString();
+
+    document.querySelector(getSelector(".elsie-next")).disabled = step >= max_step;
+    document.querySelector(getSelector(".elsie-previous")).disabled = step <= 1;
+    document.querySelector(getSelector(".elsie-current-step")).innerText = "Step: " + step_str;
+
+    var items = document.querySelectorAll(getSelector(".elsie-step"));
+    for (var i = 0; i < items.length; i++) {
+        items[i].style.display = "none";
+    }
+    document.querySelector(getSelector(".elsie-step.step-" + step_str)).style.display = "block";
+}
+function moveStep(offset) {
+    var new_step = active_step + offset;
+    if (new_step >= 1 && new_step <= max_step) {
+        active_step = new_step;
+    }
+    updateState(active_step);
+}
+document.querySelector(getSelector(".elsie-next")).addEventListener('click', function() {
+    moveStep(1);
+});
+document.querySelector(getSelector(".elsie-previous")).addEventListener('click', function() {
+    moveStep(-1);
+});
+updateState(active_step);
+"""
+
+    return "<script type='text/javascript'>(function () {" + p1 + p2 + "})()</script>"
+
+
+CSS = """
+.elsie-controls {
+    display: flex;
+    align-items: center;
+}
+.elsie-controls * {
+    margin: 0 10px;
+}
+"""
+
+
+def render_slide(slide: Slide) -> str:
+    items = slide.slides.render(None, return_svg=True, select_slides=[slide])
+    fragments = tuple(
+        f"<div class='elsie-step step-{index + 1}'>{item[2]}</div>"
+        for (index, item) in enumerate(items)
+    )
+    fragments_text = "\n".join(fragments)
+
+    slide_id = f"elsie-slide-{uuid.uuid4().hex}"
+    content = f"""
+<div class="{slide_id}">
+    {fragments_text}
+</div>
+"""
+    if len(fragments) > 1:
+        content += f"""
+<div class="elsie-controls {slide_id}">
+    <button class="elsie-previous"><</button>
+    <div class="elsie-current-step">Step: 1</div>
+    <button class="elsie-next">></button>
+</div>
+{get_javascript(len(fragments), slide_id)}
+<style>{CSS}</style>"""
+
+    return content
+
+
+# https://stackoverflow.com/a/22424821/1107768
+def is_inside_notebook():
+    try:
+        from IPython import get_ipython
+
+        ipython = get_ipython()
+        if not ipython:
+            return False
+        if "IPKernelApp" not in ipython.config:
+            return False
+    except ImportError:
+        return False
+    return True

--- a/elsie/slidecls.py
+++ b/elsie/slidecls.py
@@ -15,6 +15,7 @@ from .sxml import Xml
 class Slide:
     def __init__(
         self,
+        slides,
         index,
         width,
         height,
@@ -25,6 +26,7 @@ class Slide:
         name,
         debug_boxes,
     ):
+        self.slides = slides
         self.name = name
         self.width = width
         self.height = height
@@ -90,6 +92,11 @@ class Slide:
                 inkscape_bin, source, target, export_type
             ),
         )
+
+    def _repr_html_(self):
+        from . import jupyter
+
+        return jupyter.render_slide(self)
 
 
 class DummyPdfSlide:

--- a/examples/jupyter/jupyter.ipynb
+++ b/examples/jupyter/jupyter.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import elsie\n",
+    "\n",
+    "slides = elsie.Slides(320, 280)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from ipywidgets import interact\n",
+    "import ipywidgets as widgets\n",
+    "\n",
+    "# Using `ipywidgets`, you can create interactive slides.\n",
+    "# After each change of the slider, the slide will re-render.\n",
+    "def interactive_slide(x):\n",
+    "    @slides.slide()\n",
+    "    def slide_fn(slide):\n",
+    "        slide.box().text(f\"X: {x}\")\n",
+    "        row = slide.box(horizontal=True)\n",
+    "        for _ in range(x):\n",
+    "            row.box(width=50, height=50, padding=10).rect(bg_color=\"red\")\n",
+    "    return slide_fn\n",
+    "\n",
+    "interact(interactive_slide, x=widgets.IntSlider(min=1, max=5, step=1, continuous_update=False));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Slides with multiple fragments (steps) will include buttons to move to the previous/next step.\n",
+    "@slides.slide()\n",
+    "def multistep_slide(slide):\n",
+    "    slide.box().text(f\"Step 1\")\n",
+    "    slide.box(show=\"next+\").text(f\"Step 2\")\n",
+    "    slide.box(show=\"next+\").text(f\"Step 3\")\n",
+    "multistep_slide"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -1,0 +1,13 @@
+def test_no_js_with_single_step(test_env):
+    slide = test_env.slide
+    slide.box().text("Hello")
+
+    assert "<script" not in slide._repr_html_()
+
+
+def test_has_js_with_multiple_steps(test_env):
+    slide = test_env.slide
+    slide.box().text("Hello")
+    slide.box(show="next+").text("World")
+
+    assert "<script" in slide._repr_html_()

--- a/tests/test_slides.py
+++ b/tests/test_slides.py
@@ -31,7 +31,7 @@ def test_name_policy_ignore():
     assert len(slides._slides) == 3
 
 
-def test_name_policy_ignore():
+def test_name_policy_replace():
     slides = Slides(name_policy="replace")
     slides.new_slide(name="xxx")
     slides.new_slide(name="yyy")


### PR DESCRIPTION
Renders slides in Jupyter cells and adds buttons to move between steps.

![elsie-jupyter-1](https://user-images.githubusercontent.com/4539057/101646062-59415c00-3a37-11eb-82ef-19f6dded2e23.gif)
![elsie-jupyter-2](https://user-images.githubusercontent.com/4539057/101646078-5c3c4c80-3a37-11eb-8916-7dca6de6129e.gif)

Unresolved questions: how to deal with "slide memory leak" in Jupyter when the user does not use `name`? Automatically set `name` on the containing function in Jupyter cells?

I changed `name_policy` default to `ignore` instead of `unique`. The latter is IMO too strict to be used by default.