### PR TITLE
Inkscape Windows default path fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ slides.render("slides.pdf")
     - You can find installation instructions [here](https://wiki.inkscape.org/wiki/index.php/Installing_Inkscape)
     - Versions under 1.0 and above 0.92 might also work, but they are not primarily supported
     - Elsie uses Inkscape in the background, you do not have to know how to use it
+	- For Windows set ELSIE_INKSCAPE env variable to Inkscape bin
 - `pdflatex`, `pdf2svg` (required only for `LaTeX` support)
 
 ### Installation using pip

--- a/elsie/render/backends/svg/backend.py
+++ b/elsie/render/backends/svg/backend.py
@@ -36,7 +36,7 @@ class InkscapeBackend(Backend):
             self.inkscape = inkscape
         else:
             inkscape_bin = (
-                inkscape or os.environ.get("ELSIE_INKSCAPE") or "/usr/bin/inkscape"
+                inkscape or os.environ.get("ELSIE_INKSCAPE") or "C:/Program Files/Inkscape/bin/inkscape.exe" or "/usr/bin/inkscape"
             )
             self.inkscape = InkscapeShell(inkscape_bin)
 


### PR DESCRIPTION
Fixed Error on Windows: Inkscape bin file Not Found Error.